### PR TITLE
Add Sepolia configuration to .env.sample with instructions

### DIFF
--- a/docker-compose/.env.sample
+++ b/docker-compose/.env.sample
@@ -1,7 +1,37 @@
+# =============================================================================
+# FACET NODE CONFIGURATION
+# =============================================================================
+#
+# This file contains configuration for both Mainnet and Sepolia networks.
+#
+# TO USE MAINNET: Keep the mainnet section uncommented (default)
+# TO USE SEPOLIA: Comment out the mainnet section and uncomment the sepolia section
+#
+# =============================================================================
+
 JWT_SECRET="0x0101010101010101010101010101010101010101010101010101010101010101"
+
+# =============================================================================
+# MAINNET CONFIGURATION (DEFAULT - CURRENTLY ACTIVE)
+# =============================================================================
 GENESIS_FILE=facet-mainnet.json
 L1_NETWORK=mainnet
 L1_RPC_URL="https://eth_rpc_url"
 L1_GENESIS_BLOCK=21373000
 BLOCK_IMPORT_BATCH_SIZE=10
 BLUEBIRD_TIMESTAMP=1751844539
+
+# =============================================================================
+# SEPOLIA TESTNET CONFIGURATION (COMMENTED OUT)
+# =============================================================================
+# To use Sepolia testnet:
+# 1. Comment out the mainnet section above
+# 2. Uncomment the lines below
+# 3. Replace "your_sepolia_rpc_url" with your actual Sepolia RPC endpoint
+#
+# GENESIS_FILE=facet-sepolia.json
+# L1_NETWORK=sepolia
+# L1_RPC_URL="your_sepolia_rpc_url"
+# L1_GENESIS_BLOCK=7201200
+# BLOCK_IMPORT_BATCH_SIZE=10
+# BLUEBIRD_TIMESTAMP=1751208096


### PR DESCRIPTION
Hello guys

This PR adds Sepolia configuration section to .env.sample with clear instructions for switching between mainnet and testnet.

**Changes:**
- Added commented Sepolia configuration section
- Included Bluebird timestamp for Sepolia (1751208096)
- Added switching instructions
- Mainnet remains default

**Usage:**
Comment out mainnet section and uncomment Sepolia section to switch networks.