### PR TITLE
Improve batch wire format

### DIFF
--- a/app/models/facet_batch_constants.rb
+++ b/app/models/facet_batch_constants.rb
@@ -1,18 +1,18 @@
 # Constants for Facet Batch V2 protocol
 module FacetBatchConstants
-  # Magic prefix to identify batch payloads (8 bytes)
-  MAGIC_PREFIX = ByteString.from_hex("0x0000000000012345")
+  # Magic prefix ("unstoppable sequencing" ASCII -> hex)
+  MAGIC_PREFIX = ByteString.from_hex("0x756e73746f707061626c652073657175656e63696e67")
 
   # Protocol version
   VERSION = 1
 
   # Wire format header sizes (in bytes)
-  MAGIC_SIZE = 8
+  MAGIC_SIZE = MAGIC_PREFIX.to_bin.bytesize
   CHAIN_ID_SIZE = 8    # uint64
   VERSION_SIZE = 1     # uint8
   ROLE_SIZE = 1        # uint8
   LENGTH_SIZE = 4      # uint32
-  HEADER_SIZE = MAGIC_SIZE + CHAIN_ID_SIZE + VERSION_SIZE + ROLE_SIZE + LENGTH_SIZE  # 22 bytes
+  HEADER_SIZE = MAGIC_SIZE + CHAIN_ID_SIZE + VERSION_SIZE + ROLE_SIZE + LENGTH_SIZE  # 36 bytes
   SIGNATURE_SIZE = 65  # secp256k1: r(32) + s(32) + v(1)
 
   # Wire format offsets

--- a/app/models/facet_batch_constants.rb
+++ b/app/models/facet_batch_constants.rb
@@ -1,22 +1,39 @@
 # Constants for Facet Batch V2 protocol
 module FacetBatchConstants
-  # Magic prefix to identify batch payloads
+  # Magic prefix to identify batch payloads (8 bytes)
   MAGIC_PREFIX = ByteString.from_hex("0x0000000000012345")
-  
+
   # Protocol version
   VERSION = 1
-  
+
+  # Wire format header sizes (in bytes)
+  MAGIC_SIZE = 8
+  CHAIN_ID_SIZE = 8    # uint64
+  VERSION_SIZE = 1     # uint8
+  ROLE_SIZE = 1        # uint8
+  LENGTH_SIZE = 4      # uint32
+  HEADER_SIZE = MAGIC_SIZE + CHAIN_ID_SIZE + VERSION_SIZE + ROLE_SIZE + LENGTH_SIZE  # 22 bytes
+  SIGNATURE_SIZE = 65  # secp256k1: r(32) + s(32) + v(1)
+
+  # Wire format offsets
+  MAGIC_OFFSET = 0
+  CHAIN_ID_OFFSET = MAGIC_SIZE
+  VERSION_OFFSET = CHAIN_ID_OFFSET + CHAIN_ID_SIZE
+  ROLE_OFFSET = VERSION_OFFSET + VERSION_SIZE
+  LENGTH_OFFSET = ROLE_OFFSET + ROLE_SIZE
+  RLP_OFFSET = HEADER_SIZE
+
   # Size limits
   MAX_BATCH_BYTES = Integer(ENV.fetch('MAX_BATCH_BYTES', 131_072))  # 128KB default
   MAX_TXS_PER_BATCH = Integer(ENV.fetch('MAX_TXS_PER_BATCH', 1000))
   MAX_BATCHES_PER_PAYLOAD = Integer(ENV.fetch('MAX_BATCHES_PER_PAYLOAD', 10))
-  
+
   # Batch roles
   module Role
-    FORCED = 0x00    # Anyone can post, no signature required
-    PRIORITY = 0x01  # Requires authorized signature
+    PERMISSIONLESS = 0x00  # Anyone can post, no signature required (formerly FORCED)
+    PRIORITY = 0x01        # Requires authorized signature
   end
-  
+
   # Source types for tracking where batch came from
   module Source
     CALLDATA = 'calldata'

--- a/app/models/parsed_batch.rb
+++ b/app/models/parsed_batch.rb
@@ -1,17 +1,15 @@
 # Represents a parsed and validated Facet batch
 class ParsedBatch < T::Struct
   extend T::Sig
-  
-  const :role, Integer                           # FORCED or PRIORITY
-  const :signer, T.nilable(Address20)           # Signer address (nil if not verified or forced)
-  const :target_l1_block, Integer               # L1 block this batch targets
+
+  const :role, Integer                           # PERMISSIONLESS or PRIORITY
+  const :signer, T.nilable(Address20)           # Signer address (nil if not verified or permissionless)
   const :l1_tx_index, Integer                   # Transaction index in L1 block
-  const :source, String                         # Where batch came from (calldata/event/blob)
+  const :source, String                         # Where batch came from (calldata/blob)
   const :source_details, T::Hash[Symbol, T.untyped]  # Additional source info (tx_hash, blob_index, etc.)
   const :transactions, T::Array[ByteString]     # Array of EIP-2718 typed transaction bytes
-  const :content_hash, Hash32                   # Keccak256 of encoded batch for deduplication
-  const :chain_id, Integer                      # Chain ID from batch
-  const :extra_data, T.nilable(ByteString)      # Optional extra data field
+  const :content_hash, Hash32                   # Keccak256 of RLP_TX_LIST for deduplication
+  const :chain_id, Integer                      # Chain ID from batch header
   
   sig { returns(T::Boolean) }
   def is_priority?
@@ -19,8 +17,8 @@ class ParsedBatch < T::Struct
   end
   
   sig { returns(T::Boolean) }
-  def is_forced?
-    role == FacetBatchConstants::Role::FORCED
+  def is_permissionless?
+    role == FacetBatchConstants::Role::PERMISSIONLESS
   end
   
   sig { returns(Integer) }

--- a/app/models/standard_l2_transaction.rb
+++ b/app/models/standard_l2_transaction.rb
@@ -199,6 +199,8 @@ class StandardL2Transaction < T::Struct
     # Handle both string and Eth::Address object returns
     address_hex = address.is_a?(String) ? address : address.to_s
     Address20.from_hex(address_hex)
+  rescue Secp256k1::DeserializationError => e
+    raise DecodeError, "Failed to recover EIP-1559 address: #{e.message}"
   end
   
   def self.recover_address_eip2930(decoded, v, r, s, chain_id)

--- a/app/services/batch_signature_verifier.rb
+++ b/app/services/batch_signature_verifier.rb
@@ -1,99 +1,54 @@
-# EIP-712 signature verification for Facet batches
+# Signature verification for Facet batches
 class BatchSignatureVerifier
   include SysConfig
-  
-  # EIP-712 domain
-  DOMAIN_NAME = "FacetBatch"
-  DOMAIN_VERSION = "1"
-  
-  # Type hash for FacetBatchData
-  # struct FacetBatchData {
-  #   uint8 version;
-  #   uint256 chainId;
-  #   uint8 role;
-  #   uint64 targetL1Block;
-  #   bytes[] transactions;
-  #   bytes extraData;
-  # }
-  BATCH_DATA_TYPE_HASH = Eth::Util.keccak256(
-    "FacetBatchData(uint8 version,uint256 chainId,uint8 role,uint64 targetL1Block,bytes[] transactions,bytes extraData)"
-  )
-  
+
   attr_reader :chain_id
-  
+
   def initialize(chain_id: ChainIdManager.current_l2_chain_id)
     @chain_id = chain_id
   end
-  
-  # Verify a batch signature and return the signer address
-  # Returns nil if signature is invalid or missing
-  # batch_data_rlp: The RLP array [version, chainId, role, targetL1Block, transactions[], extraData]
-  def verify(batch_data_rlp, signature)
+
+  # Verify signature for new wire format
+  # signed_data: [CHAIN_ID:8][VERSION:1][ROLE:1][RLP_TX_LIST]
+  # signature: 65-byte secp256k1 signature
+  def verify_wire_format(signed_data, signature)
     return nil unless signature
-    
+
     sig_bytes = signature.is_a?(ByteString) ? signature.to_bin : signature
     return nil unless sig_bytes.length == 65
-    
-    # Calculate EIP-712 hash of the RLP-encoded batch data
-    message_hash = eip712_hash_rlp(batch_data_rlp)
-    
+
+    # Hash the signed data
+    message_hash = Eth::Util.keccak256(signed_data)
+
     # Recover signer from signature
     recover_signer(message_hash, sig_bytes)
-  rescue => e
-    Rails.logger.debug "Signature verification failed: #{e.message}"
-    nil
-  end
-  
-  private
-  
-  def domain_separator
-    # EIP-712 domain separator
-    @domain_separator ||= begin
-      domain_type_hash = Eth::Util.keccak256(
-        "EIP712Domain(string name,string version,uint256 chainId)"
-      )
-      
-      encoded = [
-        domain_type_hash,
-        Eth::Util.keccak256(DOMAIN_NAME),
-        Eth::Util.keccak256(DOMAIN_VERSION),
-        Eth::Util.zpad_int(chain_id, 32)
-      ].join
-      
-      Eth::Util.keccak256(encoded)
+  rescue StandardError => e
+    if signature_error?(e)
+      Rails.logger.debug "Signature verification failed: #{e.message}"
+      nil
+    else
+      raise
     end
   end
-  
-  def eip712_hash_rlp(batch_data_rlp)
-    # For RLP batches, we sign the keccak256 of the RLP-encoded FacetBatchData
-    # This is simpler and more standard than EIP-712 structured data
-    batch_data_encoded = Eth::Rlp.encode(batch_data_rlp)
-    
-    # Create the message to sign: Ethereum signed message prefix + hash
-    message_hash = Eth::Util.keccak256(batch_data_encoded)
-    
-    # Apply EIP-191 personal message signing format
-    # "\x19Ethereum Signed Message:\n32" + message_hash
-    prefix = "\x19Ethereum Signed Message:\n32"
-    Eth::Util.keccak256(prefix + message_hash)
-  end
-  
-  def hash_transactions_array(transactions)
-    # Hash array of transactions according to EIP-712
-    # Each transaction is hashed, then the array of hashes is hashed
-    tx_hashes = transactions.map { |tx| Eth::Util.keccak256(tx.to_bin) }
-    encoded = tx_hashes.join
-    Eth::Util.keccak256(encoded)
-  end
+
+  private
   
   def recover_signer(message_hash, sig_bytes)
     # Extract r, s, v from signature
     r = sig_bytes[0, 32]
     s = sig_bytes[32, 32]
-    v = sig_bytes[64].ord
-    
-    # Adjust v for EIP-155
-    v = v < 27 ? v + 27 : v
+    raw_v = sig_bytes[64].ord
+
+    # Normalise recovery id so both {0,1} and {27,28} inputs are accepted
+    v_normalised = raw_v
+    v_normalised -= 27 if v_normalised >= 27
+
+    unless [0, 1].include?(v_normalised)
+      error_class = defined?(Eth::Signature::SignatureError) ? Eth::Signature::SignatureError : StandardError
+      raise error_class, "Invalid recovery id #{raw_v}"
+    end
+
+    v = v_normalised + 27
     
     # Create signature for recovery
     # The eth.rb gem expects r (32 bytes) + s (32 bytes) + v (variable length hex)
@@ -109,5 +64,15 @@ class BatchSignatureVerifier
     address = address.is_a?(String) ? address : address.to_s
     
     Address20.from_hex(address)
+  end
+
+  def signature_error?(error)
+    return true if defined?(Eth::Signature::SignatureError) && error.is_a?(Eth::Signature::SignatureError)
+
+    if defined?(Secp256k1) && Secp256k1.const_defined?(:Error)
+      return true if error.is_a?(Secp256k1.const_get(:Error))
+    end
+
+    false
   end
 end

--- a/app/services/facet_batch_collector.rb
+++ b/app/services/facet_batch_collector.rb
@@ -150,7 +150,6 @@ class FacetBatchCollector
     
     parser.parse_payload(
       input,
-      eth_block['number'].to_i(16),
       tx_index,
       FacetBatchConstants::Source::CALLDATA,
       source_details
@@ -188,7 +187,6 @@ class FacetBatchCollector
         
         batch_list = parser.parse_payload(
           blob_data,
-          block_number,
           carrier[:tx_index],
           FacetBatchConstants::Source::BLOB,
           source_details

--- a/sequencer/src/batch/maker.ts
+++ b/sequencer/src/batch/maker.ts
@@ -16,7 +16,7 @@ interface Transaction {
 export class BatchMaker {
   private readonly MAX_PER_SENDER = 10;
   private readonly MAX_BATCH_GAS = 30_000_000;
-  private readonly FACET_MAGIC_PREFIX = '0x0000000000012345' as Hex;
+  private readonly FACET_MAGIC_PREFIX = '0x756e73746f707061626c652073657175656e63696e67' as Hex; // "unstoppable sequencing"
   private readonly L2_CHAIN_ID: bigint;
   private readonly MAX_BLOB_SIZE = 131072; // 128KB
   private lastBatchTime = Date.now();
@@ -147,10 +147,10 @@ export class BatchMaker {
     const txList = transactions.map(tx => ('0x' + tx.raw.toString('hex')) as Hex);
     const rlpTxList = toRlp(txList);
 
-    // Build new wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+    // Build new wire format: [MAGIC:22][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
     const rlpSize = size(rlpTxList);
     const parts: Hex[] = [
-      this.FACET_MAGIC_PREFIX,                      // MAGIC: 8 bytes
+      this.FACET_MAGIC_PREFIX,                      // MAGIC: 12 bytes
       encodePacked(['uint64'], [this.L2_CHAIN_ID]), // CHAIN_ID: 8 bytes big-endian
       encodePacked(['uint8'], [1]),                 // VERSION: 1 byte
       encodePacked(['uint8'], [role]),              // ROLE: 1 byte

--- a/sequencer/src/batch/maker.ts
+++ b/sequencer/src/batch/maker.ts
@@ -33,7 +33,6 @@ export class BatchMaker {
     const database = this.db.getDatabase();
 
     // Get L1 data before starting the transaction
-    const targetL1Block = await this.getNextL1Block();
     const gasBid = await this.calculateGasBid();
 
     return database.transaction(() => {
@@ -50,10 +49,13 @@ export class BatchMaker {
       // Apply selection criteria
       const selected = this.selectTransactions(candidates, maxBytes, maxCount);
       if (selected.length === 0) return null;
-      
+
+      const role = 0; // 0 = permissionless
+      const signature: Hex | undefined = undefined;
+
       // Create Facet batch wire format
-      const wireFormat = this.createFacetWireFormat(selected, targetL1Block);
-      const contentHash = this.calculateContentHash(selected, targetL1Block);
+      const wireFormat = this.createFacetWireFormat(selected, role, signature);
+      const contentHash = this.calculateContentHash(selected, role, signature);
       
       // Check for duplicate batch
       const existing = database.prepare(
@@ -72,15 +74,14 @@ export class BatchMaker {
 
       // Create batch record with tx_hashes as JSON
       const batchResult = database.prepare(`
-        INSERT INTO batches (content_hash, wire_format, state, blob_size, gas_bid, tx_count, target_l1_block, tx_hashes)
-        VALUES (?, ?, 'open', ?, ?, ?, ?, ?)
+        INSERT INTO batches (content_hash, wire_format, state, blob_size, gas_bid, tx_count, tx_hashes)
+        VALUES (?, ?, 'open', ?, ?, ?, ?)
       `).run(
         contentHash,
         wireFormat,
         wireFormat.length,
         gasBid.toString(),
         selected.length,
-        Number(targetL1Block),
         txHashesJson
       );
 
@@ -102,11 +103,10 @@ export class BatchMaker {
         'UPDATE batches SET state = ?, sealed_at = ? WHERE id = ?'
       ).run('sealed', Date.now(), batchId);
       
-      logger.info({ 
-        batchId, 
+      logger.info({
+        batchId,
         txCount: selected.length,
-        size: wireFormat.length,
-        targetL1Block: targetL1Block.toString()
+        size: wireFormat.length
       }, 'Batch created');
       
       return batchId;
@@ -142,56 +142,55 @@ export class BatchMaker {
     return selected;
   }
   
-  private createFacetWireFormat(transactions: Transaction[], targetL1Block: bigint): Buffer {
-    // Build FacetBatchData structure
-    const batchData = [
-      toHex(1), // version
-      toHex(this.L2_CHAIN_ID), // chainId  
-      "0x" as Hex, // role (0 = FORCED)
-      toHex(targetL1Block), // targetL1Block
-      transactions.map(tx => ('0x' + tx.raw.toString('hex')) as Hex), // raw transaction bytes
-      '0x' as Hex // extraData
+  private createFacetWireFormat(transactions: Transaction[], role: number, signature?: Hex): Buffer {
+    // RLP encode transaction list only (array of raw transaction bytes)
+    const txList = transactions.map(tx => ('0x' + tx.raw.toString('hex')) as Hex);
+    const rlpTxList = toRlp(txList);
+
+    // Build new wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+    const rlpSize = size(rlpTxList);
+    const parts: Hex[] = [
+      this.FACET_MAGIC_PREFIX,                      // MAGIC: 8 bytes
+      encodePacked(['uint64'], [this.L2_CHAIN_ID]), // CHAIN_ID: 8 bytes big-endian
+      encodePacked(['uint8'], [1]),                 // VERSION: 1 byte
+      encodePacked(['uint8'], [role]),              // ROLE: 1 byte
+      toHex(rlpSize, { size: 4 }),                  // LENGTH: 4 bytes big-endian
+      rlpTxList                                     // RLP_TX_LIST
     ];
-    
-    // For forced batches, wrap in outer array: [FacetBatchData]
-    // For priority batches, it would be: [FacetBatchData, signature]
-    const wrappedBatch = [batchData];
-    
-    // RLP encode the wrapped batch
-    const batchRlp = toRlp(wrappedBatch);
-    
-    // Create wire format: magic || uint32_be(length) || rlp(batch)
-    const lengthBytes = toHex(size(batchRlp), { size: 4 });
-    const wireFormatHex = concatHex([
-      this.FACET_MAGIC_PREFIX,
-      lengthBytes,
-      batchRlp
-    ]);
-    
+
+    if (signature) {
+      parts.push(signature);
+    }
+
+    const wireFormatHex = concatHex(parts);
+
     return Buffer.from(wireFormatHex.slice(2), 'hex');
   }
-  
-  private calculateContentHash(transactions: Transaction[], targetL1Block: bigint): Buffer {
-    // Calculate content hash for deduplication
-    const batchData = [
-      toHex(1), // version
-      toHex(this.L2_CHAIN_ID), // chainId
-      "0x" as Hex, // role (0 = FORCED)  
-      toHex(targetL1Block), // targetL1Block
-      transactions.map(tx => ('0x' + tx.raw.toString('hex')) as Hex),
-      '0x' as Hex
+
+  private calculateContentHash(transactions: Transaction[], role: number, signature?: Hex): Buffer {
+    // Calculate content hash from CHAIN_ID + VERSION + ROLE + RLP_TX_LIST + SIGNATURE
+    // Including signature ensures batches with different signatures don't deduplicate
+    // For permissionless batches (no signature), hash is just chain_id + version + role + txs
+    const txList = transactions.map(tx => ('0x' + tx.raw.toString('hex')) as Hex);
+    const rlpTxList = toRlp(txList);
+
+    const parts: Hex[] = [
+      encodePacked(['uint64'], [this.L2_CHAIN_ID]), // CHAIN_ID: 8 bytes
+      encodePacked(['uint8'], [1]),                 // VERSION: 1 byte
+      encodePacked(['uint8'], [role]),              // ROLE: 1 byte
+      rlpTxList                                     // RLP_TX_LIST
     ];
-    
-    const hash = keccak256(toRlp(batchData));
+
+    if (signature) {
+      parts.push(signature);
+    }
+
+    const contentData = concatHex(parts);
+
+    const hash = keccak256(contentData);
     return Buffer.from(hash.slice(2), 'hex');
   }
   
-  private async getNextL1Block(): Promise<bigint> {
-    // Get the actual next L1 block number
-    const currentBlock = await this.l1Client.getBlockNumber();
-    return currentBlock + 1n;
-  }
-
   private async calculateGasBid(): Promise<bigint> {
     // Get actual gas prices from L1
     const fees = await this.l1Client.estimateFeesPerGas();

--- a/sequencer/src/db/schema.ts
+++ b/sequencer/src/db/schema.ts
@@ -27,7 +27,6 @@ export interface Batch {
   blob_size: number;
   gas_bid: string;
   tx_count: number;
-  target_l1_block?: number;
   tx_hashes: string; // JSON array of transaction hashes
 }
 
@@ -89,7 +88,6 @@ export const createSchema = (db: Database.Database) => {
       blob_size INTEGER NOT NULL,
       gas_bid TEXT NOT NULL,
       tx_count INTEGER NOT NULL,
-      target_l1_block INTEGER,
       tx_hashes JSON NOT NULL DEFAULT '[]' -- JSON array of transaction hashes in order
     );
     

--- a/sequencer/src/l1/monitor.ts
+++ b/sequencer/src/l1/monitor.ts
@@ -219,27 +219,29 @@ export class InclusionMonitor {
   
   private checkForDroppedTransactions(l2BlockNumber: number): void {
     const database = this.db.getDatabase();
-    
-    // Transactions submitted more than 100 L2 blocks ago but not included
-    const threshold = l2BlockNumber - 100;
-    
+
+    // Transactions submitted more than 10 minutes ago but not included
+    const tenMinutesAgo = Date.now() - (10 * 60 * 1000);
+
     const dropped = database.prepare(`
       SELECT t.hash, t.batch_id
       FROM transactions t
       JOIN batches b ON t.batch_id = b.id
-      WHERE t.state = 'submitted' 
-      AND b.target_l1_block < ?
-    `).all(threshold) as Array<{ hash: Buffer; batch_id: number }>;
-    
+      JOIN post_attempts pa ON pa.batch_id = b.id
+      WHERE t.state = 'submitted'
+      AND pa.status = 'mined'
+      AND pa.confirmed_at < ?
+    `).all(tenMinutesAgo) as Array<{ hash: Buffer; batch_id: number }>;
+
     for (const tx of dropped) {
       database.prepare(`
-        UPDATE transactions 
-        SET state = 'dropped', drop_reason = 'Not included after 100 blocks'
+        UPDATE transactions
+        SET state = 'dropped', drop_reason = 'Not included after 10 minutes'
         WHERE hash = ?
       `).run(tx.hash);
-      
-      logger.warn({ 
-        txHash: '0x' + tx.hash.toString('hex') 
+
+      logger.warn({
+        txHash: '0x' + tx.hash.toString('hex')
       }, 'Transaction dropped');
     }
   }

--- a/spec/integration/forced_tx_filtering_spec.rb
+++ b/spec/integration/forced_tx_filtering_spec.rb
@@ -113,20 +113,17 @@ RSpec.describe 'Forced Transaction Filtering' do
   def create_forced_batch_payload(transactions:, target_l1_block:)
     chain_id = ChainIdManager.current_l2_chain_id
 
-    batch_data = [
-      Eth::Util.serialize_int_to_big_endian(1), # version
-      Eth::Util.serialize_int_to_big_endian(chain_id),
-      Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),
-      Eth::Util.serialize_int_to_big_endian(target_l1_block),
-      transactions.map(&:to_bin),
-      ''
-    ]
+    # Create RLP-encoded transaction list
+    rlp_tx_list = Eth::Rlp.encode(transactions.map(&:to_bin))
 
-    facet_batch = [batch_data, '']
-    rlp_encoded = Eth::Rlp.encode(facet_batch)
+    # Build wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+    payload = FacetBatchConstants::MAGIC_PREFIX.to_bin
+    payload += [chain_id].pack('Q>')  # uint64 big-endian
+    payload += [FacetBatchConstants::VERSION].pack('C')
+    payload += [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+    payload += [rlp_tx_list.length].pack('N')
+    payload += rlp_tx_list
 
-    magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-    length = [rlp_encoded.length].pack('N')
-    ByteString.from_bin(magic + length + rlp_encoded)
+    ByteString.from_bin(payload)
   end
 end

--- a/spec/integration/forced_tx_filtering_spec.rb
+++ b/spec/integration/forced_tx_filtering_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Forced Transaction Filtering' do
     # Create RLP-encoded transaction list
     rlp_tx_list = Eth::Rlp.encode(transactions.map(&:to_bin))
 
-    # Build wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+    # Build wire format: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
     payload = FacetBatchConstants::MAGIC_PREFIX.to_bin
     payload += [chain_id].pack('Q>')  # uint64 big-endian
     payload += [FacetBatchConstants::VERSION].pack('C')

--- a/spec/mixed_transaction_types_spec.rb
+++ b/spec/mixed_transaction_types_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe "Mixed Transaction Types" do
       puts "Target L1 block for batch: #{target_block}"
       puts "Batch should contain #{[eip1559_tx].length} transaction(s)"
       
-      # Debug the batch structure - new format has 22-byte header
-      # [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
-      test_decode = Eth::Rlp.decode(batch_payload.to_bin[22..-1])  # Skip header to get RLP_TX_LIST
+      # Debug the batch structure - new format has FacetBatchConstants::HEADER_SIZE bytes
+      # [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+      test_decode = Eth::Rlp.decode(batch_payload.to_bin[FacetBatchConstants::HEADER_SIZE..-1])  # Skip header to get RLP_TX_LIST
       puts "Decoded batch has #{test_decode.length} transactions"
       
       puts "Batch payload length: #{batch_payload.to_bin.length} bytes"
@@ -357,7 +357,7 @@ RSpec.describe "Mixed Transaction Types" do
     # Create RLP-encoded transaction list
     rlp_tx_list = Eth::Rlp.encode(transactions.map(&:to_bin))
 
-    # Build wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE:65]?
+    # Build wire format: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE:65]?
     payload = FacetBatchConstants::MAGIC_PREFIX.to_bin
     payload += [chain_id].pack('Q>')  # uint64 big-endian
     payload += [FacetBatchConstants::VERSION].pack('C')

--- a/spec/mixed_transaction_types_spec.rb
+++ b/spec/mixed_transaction_types_spec.rb
@@ -73,16 +73,17 @@ RSpec.describe "Mixed Transaction Types" do
       target_block = current_max_eth_block.number + 2  # +2 because we imported funding block
       batch_payload = create_batch_payload(
         transactions: [eip1559_tx],
-        role: FacetBatchConstants::Role::FORCED,
+        role: FacetBatchConstants::Role::PERMISSIONLESS,
         target_l1_block: target_block
       )
       
       puts "Target L1 block for batch: #{target_block}"
       puts "Batch should contain #{[eip1559_tx].length} transaction(s)"
       
-      # Debug the batch structure
-      test_decode = Eth::Rlp.decode(batch_payload.to_bin[12..-1])  # Skip magic + length
-      puts "Decoded batch has #{test_decode[0][4].length} transactions"
+      # Debug the batch structure - new format has 22-byte header
+      # [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+      test_decode = Eth::Rlp.decode(batch_payload.to_bin[22..-1])  # Skip header to get RLP_TX_LIST
+      puts "Decoded batch has #{test_decode.length} transactions"
       
       puts "Batch payload length: #{batch_payload.to_bin.length} bytes"
       puts "Batch payload hex (first 100 chars): #{batch_payload.to_hex[0..100]}"
@@ -219,7 +220,7 @@ RSpec.describe "Mixed Transaction Types" do
       
       forced_batch = create_batch_payload(
         transactions: [forced_tx],
-        role: FacetBatchConstants::Role::FORCED,
+        role: FacetBatchConstants::Role::PERMISSIONLESS,
         target_l1_block: current_max_eth_block.number + 1
       )
       
@@ -352,35 +353,25 @@ RSpec.describe "Mixed Transaction Types" do
   
   def create_batch_payload(transactions:, role:, target_l1_block:, sign: false)
     chain_id = ChainIdManager.current_l2_chain_id
-    
-    # FacetBatchData = [version, chainId, role, targetL1Block, transactions[], extraData]
-    batch_data = [
-      Eth::Util.serialize_int_to_big_endian(1),  # version
-      Eth::Util.serialize_int_to_big_endian(chain_id),  # chainId
-      Eth::Util.serialize_int_to_big_endian(role),  # role
-      Eth::Util.serialize_int_to_big_endian(target_l1_block),  # targetL1Block
-      transactions.map(&:to_bin),  # transactions array - ACTUALLY include them!
-      ''  # extraData
-    ]
-    
-    # FacetBatch = [FacetBatchData, signature]
-    # Always include signature field (can be empty string for non-priority)
+
+    # Create RLP-encoded transaction list
+    rlp_tx_list = Eth::Rlp.encode(transactions.map(&:to_bin))
+
+    # Build wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE:65]?
+    payload = FacetBatchConstants::MAGIC_PREFIX.to_bin
+    payload += [chain_id].pack('Q>')  # uint64 big-endian
+    payload += [FacetBatchConstants::VERSION].pack('C')
+    payload += [role].pack('C')
+    payload += [rlp_tx_list.length].pack('N')
+    payload += rlp_tx_list
+
+    # Add signature for priority batches
     if sign && role == FacetBatchConstants::Role::PRIORITY
-      # Add dummy signature for priority batches
-      signature = "\x00" * 64 + "\x01"  # 65 bytes
-    else
-      signature = ''  # Empty signature for forced batches
+      # Add dummy signature for priority batches (65 bytes: r:32, s:32, v:1)
+      signature = "\x00" * 32 + "\x00" * 32 + "\x01"
+      payload += signature
     end
-    
-    facet_batch = [batch_data, signature]  # Always 2 elements
-    
-    # Encode with RLP
-    rlp_encoded = Eth::Rlp.encode(facet_batch)
-    
-    # Add wire format header
-    magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-    length = [rlp_encoded.length].pack('N')
-    
-    ByteString.from_bin(magic + length + rlp_encoded)
+
+    ByteString.from_bin(payload)
   end
 end

--- a/spec/models/standard_l2_transaction_signature_recovery_spec.rb
+++ b/spec/models/standard_l2_transaction_signature_recovery_spec.rb
@@ -79,10 +79,7 @@ RSpec.describe StandardL2Transaction do
         invalid_s = "\x00" * 32
         tx_data = [chain_id, 1, 100000, 200000, 21000, to_address, 1000000, "", []]
         
-        recovered = StandardL2Transaction.recover_address_eip1559(tx_data, 0, invalid_r, invalid_s, chain_id)
-        
-        # Should return null address without crashing
-        expect(recovered.to_hex).to eq("0x" + "0" * 40)
+        expect { StandardL2Transaction.recover_address_eip1559(tx_data, 0, invalid_r, invalid_s, chain_id) }.to raise_error(StandardL2Transaction::DecodeError)
       end
     end
     

--- a/spec/services/batch_signature_verifier_spec.rb
+++ b/spec/services/batch_signature_verifier_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe BatchSignatureVerifier do
+  let(:chain_id) { ChainIdManager.current_l2_chain_id }
+  let(:verifier) { described_class.new(chain_id: chain_id) }
+  let(:key) { Eth::Key.new }
+
+  def build_signed_data(role: FacetBatchConstants::Role::PRIORITY)
+    tx_list = Eth::Rlp.encode([])
+    [
+      [chain_id].pack('Q>'),
+      [FacetBatchConstants::VERSION].pack('C'),
+      [role].pack('C'),
+      tx_list
+    ].join
+  end
+
+  def build_signature(message_hash)
+    signature_hex = key.sign(message_hash).sub(/^0x/, '')
+    [signature_hex].pack('H*')
+  end
+
+  describe '#verify_wire_format' do
+    it 'accepts signatures with legacy v values (27/28)' do
+      signed_data = build_signed_data
+      message_hash = Eth::Util.keccak256(signed_data)
+      signature = build_signature(message_hash)
+
+      signer = verifier.verify_wire_format(signed_data, signature)
+
+      expect(signer.to_hex.downcase).to eq(key.address.to_s.downcase)
+    end
+
+    it 'accepts signatures with normalised v values (0/1)' do
+      signed_data = build_signed_data
+      message_hash = Eth::Util.keccak256(signed_data)
+      signature = build_signature(message_hash)
+
+      normalised_signature = signature.dup
+      normalised_signature.setbyte(64, normalised_signature.getbyte(64) - 27)
+
+      signer = verifier.verify_wire_format(signed_data, normalised_signature)
+
+      expect(signer.to_hex.downcase).to eq(key.address.to_s.downcase)
+    end
+
+    it 'returns nil for signatures with invalid recovery ids' do
+      signed_data = build_signed_data
+      message_hash = Eth::Util.keccak256(signed_data)
+      signature = build_signature(message_hash)
+
+      invalid_signature = signature.dup
+      invalid_signature.setbyte(64, 5)
+
+      signer = verifier.verify_wire_format(signed_data, invalid_signature)
+
+      expect(signer).to be_nil
+    end
+  end
+end

--- a/spec/services/blob_aggregation_spec.rb
+++ b/spec/services/blob_aggregation_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Blob Aggregation Scenarios' do
       # Create RLP-encoded transaction list
       rlp_tx_list = Eth::Rlp.encode(transactions.map(&:to_bin))
 
-      # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+      # Construct wire format: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
       payload = FacetBatchConstants::MAGIC_PREFIX.to_bin
       payload += [chain_id].pack('Q>')  # uint64 big-endian
       payload += [FacetBatchConstants::VERSION].pack('C')

--- a/spec/services/blob_aggregation_spec.rb
+++ b/spec/services/blob_aggregation_spec.rb
@@ -61,11 +61,14 @@ RSpec.describe 'Blob Aggregation Scenarios' do
     end
     
     it 'handles batch that claims size beyond blob boundary' do
-      # Create batch that claims to be huge
-      magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-      huge_size = [200_000].pack('N')  # Claims 200KB but blob is only 128KB
-      
-      blob_data = magic + huge_size + ("\x00".b * 100)
+      # Create batch header that claims to be huge
+      chain_id = ChainIdManager.current_l2_chain_id
+
+      blob_data = FacetBatchConstants::MAGIC_PREFIX.to_bin
+      blob_data += [chain_id].pack('Q>')  # uint64 big-endian
+      blob_data += [FacetBatchConstants::VERSION].pack('C')
+      blob_data += [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+      blob_data += [200_000].pack('N')  # Claims 200KB but blob is only 128KB
       blob_data += "\x00".b * (131_072 - blob_data.length)
       
       blob = ByteString.from_bin(blob_data)
@@ -82,37 +85,19 @@ RSpec.describe 'Blob Aggregation Scenarios' do
         create_test_transaction(nonce: i, value: 1000 * (i + 1))
       end
       
-      # Create batch
-      batch = ParsedBatch.new(
-        role: FacetBatchConstants::Role::FORCED,
-        signer: nil,
-        target_l1_block: 12345,
-        l1_tx_index: 0,
-        source: FacetBatchConstants::Source::BLOB,
-        source_details: {},
-        transactions: transactions,
-        content_hash: Hash32.from_bin(Eth::Util.keccak256("test")),
-        chain_id: ChainIdManager.current_l2_chain_id,
-        extra_data: ByteString.from_bin("".b)
-      )
-      
-      # Encode for blob
-      batch_data = [
-        Eth::Util.serialize_int_to_big_endian(1),
-        Eth::Util.serialize_int_to_big_endian(batch.chain_id),
-        Eth::Util.serialize_int_to_big_endian(batch.role),
-        Eth::Util.serialize_int_to_big_endian(batch.target_l1_block),
-        batch.transactions.map(&:to_bin),
-        ''
-      ]
-      
-      facet_batch = [batch_data, '']
-      rlp_encoded = Eth::Rlp.encode(facet_batch)
-      
-      # Add wire format
+      # Create batch in new wire format
+      chain_id = ChainIdManager.current_l2_chain_id
+
+      # Create RLP-encoded transaction list
+      rlp_tx_list = Eth::Rlp.encode(transactions.map(&:to_bin))
+
+      # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
       payload = FacetBatchConstants::MAGIC_PREFIX.to_bin
-      payload += [rlp_encoded.length].pack('N')
-      payload += rlp_encoded
+      payload += [chain_id].pack('Q>')  # uint64 big-endian
+      payload += [FacetBatchConstants::VERSION].pack('C')
+      payload += [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+      payload += [rlp_tx_list.length].pack('N')
+      payload += rlp_tx_list
       
       # Embed in blob
       blob_data = payload + ("\x00".b * (131_072 - payload.length))
@@ -122,16 +107,15 @@ RSpec.describe 'Blob Aggregation Scenarios' do
       parser = FacetBatchParser.new
       parsed_batches = parser.parse_payload(
         blob,
-        batch.target_l1_block,
-        0,
+        0,      # l1_tx_index
         FacetBatchConstants::Source::BLOB
       )
-      
+
       expect(parsed_batches.length).to eq(1)
       parsed = parsed_batches.first
-      
-      expect(parsed.role).to eq(batch.role)
-      expect(parsed.target_l1_block).to eq(batch.target_l1_block)
+
+      expect(parsed.role).to eq(FacetBatchConstants::Role::PERMISSIONLESS)
+      expect(parsed.chain_id).to eq(chain_id)
       expect(parsed.transactions.length).to eq(3)
       expect(parsed.transactions.map(&:to_bin)).to eq(transactions.map(&:to_bin))
     end

--- a/spec/services/facet_batch_collector_spec.rb
+++ b/spec/services/facet_batch_collector_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe FacetBatchCollector do
     # Create empty transaction list
     rlp_tx_list = Eth::Rlp.encode([])
 
-    # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+    # Construct wire format: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
     magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
     chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
     version_byte = [FacetBatchConstants::VERSION].pack('C')  # uint8

--- a/spec/services/facet_batch_collector_spec.rb
+++ b/spec/services/facet_batch_collector_spec.rb
@@ -262,29 +262,19 @@ RSpec.describe FacetBatchCollector do
   end
   
   def create_batch_payload
-    # Create a valid RLP batch payload with magic prefix
+    # Create a valid batch in new wire format
     chain_id = ChainIdManager.current_l2_chain_id
-    
-    # FacetBatchData = [version, chainId, role, targetL1Block, transactions[], extraData]
-    batch_data = [
-      Eth::Util.serialize_int_to_big_endian(1),  # version
-      Eth::Util.serialize_int_to_big_endian(chain_id),  # chainId
-      Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),  # role
-      Eth::Util.serialize_int_to_big_endian(block_number),  # targetL1Block
-      [],  # transactions (empty array)
-      ''   # extraData (empty)
-    ]
-    
-    # FacetBatch = [FacetBatchData, signature]
-    facet_batch = [batch_data, '']  # Empty signature for forced batch
-    
-    # Encode with RLP
-    rlp_encoded = Eth::Rlp.encode(facet_batch)
-    
-    # Add wire format header
+
+    # Create empty transaction list
+    rlp_tx_list = Eth::Rlp.encode([])
+
+    # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
     magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-    length = [rlp_encoded.length].pack('N')
-    
-    ByteString.from_bin(magic + length + rlp_encoded)
+    chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
+    version_byte = [FacetBatchConstants::VERSION].pack('C')  # uint8
+    role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')  # uint8
+    length_bytes = [rlp_tx_list.length].pack('N')  # uint32 big-endian
+
+    ByteString.from_bin(magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list)
   end
 end

--- a/spec/services/facet_batch_parser_spec.rb
+++ b/spec/services/facet_batch_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FacetBatchParser do
       end
 
       let(:payload) do
-        # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+        # Construct wire format: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
         magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
         chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
         version_byte = [FacetBatchConstants::VERSION].pack('C')  # uint8
@@ -187,7 +187,7 @@ RSpec.describe FacetBatchParser do
       # Build wire format batch for chain_id 0xface7b (16436859)
       chain_id = 0xface7b
 
-      # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+      # Construct wire format: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
       magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
       chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
       version_byte = [FacetBatchConstants::VERSION].pack('C')
@@ -234,7 +234,7 @@ RSpec.describe FacetBatchParser do
 
       chain_id = 0xface7b
 
-      # Construct wire format for priority batch: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE:65]
+      # Construct wire format for priority batch: [MAGIC:#{FacetBatchConstants::MAGIC_SIZE}][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE:65]
       magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
       chain_id_bytes = [chain_id].pack('Q>')
       version_byte = [FacetBatchConstants::VERSION].pack('C')

--- a/spec/services/facet_batch_parser_spec.rb
+++ b/spec/services/facet_batch_parser_spec.rb
@@ -7,154 +7,139 @@ RSpec.describe FacetBatchParser do
   let(:l1_tx_index) { 5 }
   
   describe '#parse_payload' do
-    context 'with valid batch' do
-      let(:batch_data) do
-        # RLP encoding for testing
-        batch_data = [
-          Eth::Util.serialize_int_to_big_endian(1),  # version
-          Eth::Util.serialize_int_to_big_endian(chain_id),  # chainId
-          Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),  # role
-          Eth::Util.serialize_int_to_big_endian(l1_block_number),  # targetL1Block
-          [],  # transactions (empty array)
-          ''   # extraData (empty)
-        ]
-        
-        # FacetBatch = [FacetBatchData, signature]
-        Eth::Rlp.encode([batch_data, ''])  # Empty signature for forced batch
+    context 'with valid permissionless batch' do
+      let(:rlp_tx_list) do
+        # Empty transaction list for testing
+        Eth::Rlp.encode([])
       end
-      
+
       let(:payload) do
+        # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
         magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-        length = [batch_data.length].pack('N')  # uint32 big-endian
-        
-        ByteString.from_bin(magic + length + batch_data)
+        chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
+        version_byte = [FacetBatchConstants::VERSION].pack('C')  # uint8
+        role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')  # uint8
+        length_bytes = [rlp_tx_list.length].pack('N')  # uint32 big-endian
+
+        ByteString.from_bin(magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list)
       end
-      
+
       it 'parses a valid batch' do
-        batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
-        
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+
         expect(batches.length).to eq(1)
         batch = batches.first
-        
-        expect(batch.role).to eq(FacetBatchConstants::Role::FORCED)
-        expect(batch.target_l1_block).to eq(l1_block_number)
+
+        expect(batch.role).to eq(FacetBatchConstants::Role::PERMISSIONLESS)
         expect(batch.l1_tx_index).to eq(l1_tx_index)
         expect(batch.chain_id).to eq(chain_id)
         expect(batch.transactions).to be_empty
+        expect(batch.signer).to be_nil
       end
     end
     
     context 'with invalid version' do
-      let(:batch_data) do
-        batch_data = [
-          Eth::Util.serialize_int_to_big_endian(2),  # Wrong version
-          Eth::Util.serialize_int_to_big_endian(chain_id),
-          Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),
-          Eth::Util.serialize_int_to_big_endian(l1_block_number),
-          [],
-          ''
-        ]
-        Eth::Rlp.encode([batch_data])
+      let(:rlp_tx_list) do
+        Eth::Rlp.encode([])
       end
-      
+
       let(:payload) do
         magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-        length = [batch_data.length].pack('N')
-        ByteString.from_bin(magic + length + batch_data)
+        chain_id_bytes = [chain_id].pack('Q>')
+        version_byte = [2].pack('C')  # Wrong version
+        role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+        length_bytes = [rlp_tx_list.length].pack('N')
+
+        ByteString.from_bin(magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list)
       end
-      
+
       it 'rejects batch with wrong version' do
-        batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
         expect(batches).to be_empty
       end
     end
     
     context 'with wrong chain ID' do
-      let(:batch_data) do
-        batch_data = [
-          Eth::Util.serialize_int_to_big_endian(1),  # version
-          Eth::Util.serialize_int_to_big_endian(999999),  # Wrong chain ID
-          Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),  # role
-          Eth::Util.serialize_int_to_big_endian(l1_block_number),  # targetL1Block
-          [],  # transactions
-          ''   # extraData
-        ]
-        Eth::Rlp.encode([batch_data])
+      let(:rlp_tx_list) do
+        Eth::Rlp.encode([])
       end
-      
+
       let(:payload) do
         magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-        length = [batch_data.length].pack('N')
-        ByteString.from_bin(magic + length + batch_data)
+        chain_id_bytes = [999999].pack('Q>')  # Wrong chain ID
+        version_byte = [FacetBatchConstants::VERSION].pack('C')
+        role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+        length_bytes = [rlp_tx_list.length].pack('N')
+
+        ByteString.from_bin(magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list)
       end
-      
-      it 'rejects batch with wrong chain ID' do
-        batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+
+      it 'skips batch with wrong chain ID without parsing RLP' do
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
         expect(batches).to be_empty
       end
     end
     
-    context 'with wrong target block' do
-      let(:batch_data) do
-        batch_data = [
-          Eth::Util.serialize_int_to_big_endian(1),  # version
-          Eth::Util.serialize_int_to_big_endian(chain_id),  # chainId
-          Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),  # role
-          Eth::Util.serialize_int_to_big_endian(99999),  # Wrong target block
-          [],  # transactions
-          ''   # extraData
-        ]
-        Eth::Rlp.encode([batch_data])
-      end
-      
-      let(:payload) do
-        magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-        length = [batch_data.length].pack('N')
-        ByteString.from_bin(magic + length + batch_data)
-      end
-      
-      # TODO
-      # it 'rejects batch with wrong target block' do
-      #   batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
-      #   expect(batches).to be_empty
-      # end
-    end
-    
     context 'with multiple batches in payload' do
-      let(:batch1) { create_valid_batch_data }
-      let(:batch2) { create_valid_batch_data }
-      
-      let(:payload) do
-        magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-        
-        batch1_with_header = magic + [batch1.length].pack('N') + batch1
-        batch2_with_header = magic + [batch2.length].pack('N') + batch2
-        
-        # Add some padding between batches
-        ByteString.from_bin(batch1_with_header + "\x00" * 10 + batch2_with_header)
+      let(:rlp_tx_list) { Eth::Rlp.encode([]) }
+
+      let(:batch1) do
+        create_valid_wire_batch(chain_id, FacetBatchConstants::Role::PERMISSIONLESS, rlp_tx_list)
       end
-      
+
+      let(:batch2) do
+        create_valid_wire_batch(chain_id, FacetBatchConstants::Role::PERMISSIONLESS, rlp_tx_list)
+      end
+
+      let(:payload) do
+        # Add some padding between batches
+        ByteString.from_bin(batch1 + "\x00" * 10 + batch2)
+      end
+
       it 'finds multiple batches' do
-        batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
         expect(batches.length).to eq(2)
       end
     end
     
     context 'with batch exceeding max size' do
-      let(:oversized_data) { "\x00" * (FacetBatchConstants::MAX_BATCH_BYTES + 1) }
-      
+      let(:oversized_rlp) { Eth::Rlp.encode(["\x00" * (FacetBatchConstants::MAX_BATCH_BYTES + 1)]) }
+
       let(:payload) do
         magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
-        length = [oversized_data.length].pack('N')
-        ByteString.from_bin(magic + length + oversized_data)
+        chain_id_bytes = [chain_id].pack('Q>')
+        version_byte = [FacetBatchConstants::VERSION].pack('C')
+        role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+        length_bytes = [oversized_rlp.length].pack('N')
+
+        ByteString.from_bin(magic + chain_id_bytes + version_byte + role_byte + length_bytes + oversized_rlp)
       end
-      
+
       it 'rejects oversized batch' do
-        batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
         expect(batches).to be_empty
       end
     end
-    
+
+    context 'with nested transaction entry' do
+      let(:malformed_rlp) { Eth::Rlp.encode([["nested"]]) }
+
+      let(:payload) do
+        magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
+        chain_id_bytes = [chain_id].pack('Q>')
+        version_byte = [FacetBatchConstants::VERSION].pack('C')
+        role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+        length_bytes = [malformed_rlp.length].pack('N')
+
+        ByteString.from_bin(magic + chain_id_bytes + version_byte + role_byte + length_bytes + malformed_rlp)
+      end
+
+      it 'rejects transaction lists with non byte-string entries' do
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+        expect(batches).to be_empty
+      end
+    end
+
     context 'with malformed length field' do
       let(:payload) do
         magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
@@ -163,7 +148,7 @@ RSpec.describe FacetBatchParser do
       end
       
       it 'handles malformed length gracefully' do
-        batches = parser.parse_payload(payload, l1_block_number, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
+        batches = parser.parse_payload(payload, l1_tx_index, FacetBatchConstants::Source::CALLDATA)
         expect(batches).to be_empty
       end
     end
@@ -171,38 +156,51 @@ RSpec.describe FacetBatchParser do
   
   private
   
-  def create_valid_batch_data
-    # Create valid RLP-encoded batch data
-    batch_data = [
-      Eth::Util.serialize_int_to_big_endian(1),  # version
-      Eth::Util.serialize_int_to_big_endian(chain_id),  # chainId
-      Eth::Util.serialize_int_to_big_endian(FacetBatchConstants::Role::FORCED),  # role
-      Eth::Util.serialize_int_to_big_endian(l1_block_number),  # targetL1Block
-      [],  # transactions (empty array)
-      ''   # extraData (empty)
-    ]
-    
-    # FacetBatch = [FacetBatchData, signature]
-    facet_batch = [batch_data, '']  # Empty signature for forced batch
-    
-    # Return RLP-encoded batch
-    Eth::Rlp.encode(facet_batch)
+  def create_valid_wire_batch(chain_id, role, rlp_tx_list, signature = nil)
+    # Create valid wire format batch
+    magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
+    chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
+    version_byte = [FacetBatchConstants::VERSION].pack('C')  # uint8
+    role_byte = [role].pack('C')  # uint8
+    length_bytes = [rlp_tx_list.length].pack('N')  # uint32 big-endian
+
+    batch = magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list
+
+    # Add signature for priority batches
+    if role == FacetBatchConstants::Role::PRIORITY && signature
+      batch += signature
+    end
+
+    batch
   end
 
   describe 'real blob parsing' do
-    # This test uses real blob data from block 1193381
-    # Original test was in test_blob_parse.rb
-    it 'parses real blob data from block 1193381' do
-      # Real blob data (already decoded from blob format via BlobUtils.from_blobs)
-      blob_hex = '0x00000000000123450000008df88bf8890183face7b008408baf03af87bb87902f87683face7b8084773594008504a817c8008252089470997970c51812dc3a010c7d01b50e0d17dc79c888016345785d8a000080c080a09319812cf80571eaf0ff69a17e27537b4faf857c4268717ada7c2645fb0efab6a077e333b17b54b397972c1920bb1088d4de3c6a705061988a35d331d6e4c2ab6c80'
+    it 'parses batch with real transaction in new format' do
+      # Create a real EIP-1559 transaction (from the old format test)
+      # This is the same transaction that was in the old blob, now in new format
+      tx_hex = '0x02f87683face7b8084773594008504a817c8008252089470997970c51812dc3a010c7d01b50e0d17dc79c888016345785d8a000080c080a09319812cf80571eaf0ff69a17e27537b4faf857c4268717ada7c2645fb0efab6a077e333b17b54b397972c1920bb1088d4de3c6a705061988a35d331d6e4c2ab60'
 
-      decoded_bytes = ByteString.from_hex(blob_hex)
-      parser = described_class.new(chain_id: 0xface7b)
- 
-      # Parse the blob
+      # Create RLP-encoded transaction list
+      tx_bytes = ByteString.from_hex(tx_hex).to_bin
+      rlp_tx_list = Eth::Rlp.encode([tx_bytes])
+
+      # Build wire format batch for chain_id 0xface7b (16436859)
+      chain_id = 0xface7b
+
+      # Construct wire format: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST]
+      magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
+      chain_id_bytes = [chain_id].pack('Q>')  # uint64 big-endian
+      version_byte = [FacetBatchConstants::VERSION].pack('C')
+      role_byte = [FacetBatchConstants::Role::PERMISSIONLESS].pack('C')
+      length_bytes = [rlp_tx_list.length].pack('N')  # uint32 big-endian
+
+      wire_batch = magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list
+
+      parser = described_class.new(chain_id: chain_id)
+
+      # Parse the batch
       batches = parser.parse_payload(
-        decoded_bytes,
-        1193381,
+        ByteString.from_bin(wire_batch),
         0,
         FacetBatchConstants::Source::BLOB,
         {}
@@ -212,7 +210,7 @@ RSpec.describe FacetBatchParser do
       expect(batches.length).to eq(1)
 
       batch = batches.first
-      expect(batch.role).to eq(FacetBatchConstants::Role::FORCED)
+      expect(batch.role).to eq(FacetBatchConstants::Role::PERMISSIONLESS)
       expect(batch.transactions).to be_an(Array)
       expect(batch.transactions.length).to eq(1)
 
@@ -224,6 +222,50 @@ RSpec.describe FacetBatchParser do
       decoded_tx = Eth::Tx.decode(tx.to_hex)
       expect(decoded_tx).to be_a(Eth::Tx::Eip1559)
       expect(decoded_tx.chain_id).to eq(0xface7b)
+    end
+
+    it 'parses priority batch with signature' do
+      # Create a simple transaction
+      tx_hex = '0x02f87683face7b8084773594008504a817c8008252089470997970c51812dc3a010c7d01b50e0d17dc79c888016345785d8a000080c080a09319812cf80571eaf0ff69a17e27537b4faf857c4268717ada7c2645fb0efab6a077e333b17b54b397972c1920bb1088d4de3c6a705061988a35d331d6e4c2ab60'
+
+      # Create RLP-encoded transaction list
+      tx_bytes = ByteString.from_hex(tx_hex).to_bin
+      rlp_tx_list = Eth::Rlp.encode([tx_bytes])
+
+      chain_id = 0xface7b
+
+      # Construct wire format for priority batch: [MAGIC:8][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE:65]
+      magic = FacetBatchConstants::MAGIC_PREFIX.to_bin
+      chain_id_bytes = [chain_id].pack('Q>')
+      version_byte = [FacetBatchConstants::VERSION].pack('C')
+      role_byte = [FacetBatchConstants::Role::PRIORITY].pack('C')
+      length_bytes = [rlp_tx_list.length].pack('N')
+
+      # Create a dummy 65-byte signature (r: 32, s: 32, v: 1)
+      signature = "\x00" * 32 + "\x00" * 32 + "\x1b"  # v=27 (0x1b)
+
+      wire_batch = magic + chain_id_bytes + version_byte + role_byte + length_bytes + rlp_tx_list + signature
+
+      parser = described_class.new(chain_id: chain_id)
+
+      # Disable signature verification for this test
+      allow(SysConfig).to receive(:enable_sig_verify?).and_return(false)
+
+      # Parse the batch
+      batches = parser.parse_payload(
+        ByteString.from_bin(wire_batch),
+        0,
+        FacetBatchConstants::Source::BLOB,
+        {}
+      )
+
+      expect(batches).not_to be_empty
+      expect(batches.length).to eq(1)
+
+      batch = batches.first
+      expect(batch.role).to eq(FacetBatchConstants::Role::PRIORITY)
+      expect(batch.transactions.length).to eq(1)
+      expect(batch.signer).to be_nil  # Since we disabled verification
     end
   end
 end

--- a/spec/services/facet_block_builder_spec.rb
+++ b/spec/services/facet_block_builder_spec.rb
@@ -189,35 +189,31 @@ RSpec.describe FacetBlockBuilder do
   
   def create_forced_batch(l1_tx_index:, tx_count:)
     transactions = tx_count.times.map { create_tx_bytes }
-    
+
     ParsedBatch.new(
-      role: FacetBatchConstants::Role::FORCED,
+      role: FacetBatchConstants::Role::PERMISSIONLESS,
       signer: nil,
-      target_l1_block: l1_block_number,
       l1_tx_index: l1_tx_index,
       source: FacetBatchConstants::Source::CALLDATA,
       source_details: {},
       transactions: transactions,
       content_hash: Hash32.from_bin(Eth::Util.keccak256(rand.to_s)),
-      chain_id: ChainIdManager.current_l2_chain_id,
-      extra_data: nil
+      chain_id: ChainIdManager.current_l2_chain_id
     )
   end
-  
+
   def create_priority_batch(l1_tx_index:, tx_count:, signer:)
     transactions = tx_count.times.map { create_tx_bytes }
-    
+
     ParsedBatch.new(
       role: FacetBatchConstants::Role::PRIORITY,
       signer: signer,
-      target_l1_block: l1_block_number,
       l1_tx_index: l1_tx_index,
       source: FacetBatchConstants::Source::CALLDATA,
       source_details: {},
       transactions: transactions,
       content_hash: Hash32.from_bin(Eth::Util.keccak256(rand.to_s)),
-      chain_id: ChainIdManager.current_l2_chain_id,
-      extra_data: nil
+      chain_id: ChainIdManager.current_l2_chain_id
     )
   end
   


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches batches to a new V2 wire format (magic + chain_id/version/role/length [+signature] + RLP tx list), renames FORCED to PERMISSIONLESS, and updates parser, verifier, sequencer, DB, and tests accordingly.
> 
> - **Protocol/Constants**
>   - Change `MAGIC_PREFIX` to ASCII "unstoppable sequencing" hex and add header sizing/offsets (`MAGIC_SIZE`, `CHAIN_ID_SIZE`, `VERSION_SIZE`, `ROLE_SIZE`, `LENGTH_SIZE`, `HEADER_SIZE`, `SIGNATURE_SIZE`).
>   - Rename role `FORCED` -> `PERMISSIONLESS`; keep `PRIORITY`.
> - **Parser (`FacetBatchParser`)**
>   - Parse new wire format: `[MAGIC][CHAIN_ID:8][VERSION:1][ROLE:1][LENGTH:4][RLP_TX_LIST][SIGNATURE?]`.
>   - Early chain ID check; remove `l1_block_number` param from `parse_payload`.
>   - Compute `content_hash` from `CHAIN_ID+VERSION+ROLE+RLP_TX_LIST(+SIGNATURE)`; decode RLP tx list; support priority signature presence.
>   - Update `ParsedBatch`: fields reflect new semantics (no `target_l1_block`, updated role method, `content_hash` meaning, `chain_id` from header, source excludes events).
> - **Signature Verification (`BatchSignatureVerifier`)**
>   - Verify over keccak256(signed_data) of header+tx list; normalize `v` (accept 0/1 or 27/28); improved error handling helper.
> - **Sequencer**
>   - `BatchMaker`: emit new wire format, include role and optional signature; update content hash; remove `target_l1_block` usage in schema and inserts; update magic prefix.
>   - DB (`schema.ts`): drop `target_l1_block` column usages in inserts and logic.
>   - L1 Monitor: update magic prefix; change dropped-tx heuristic to 10 minutes after mined post attempt (from 100 blocks).
> - **Models**
>   - `StandardL2Transaction`: raise `DecodeError` on `Secp256k1::DeserializationError` during EIP-1559 recovery.
> - **Collector**
>   - Adjust calls to `parse_payload` (no block number); parse from calldata/blobs only.
> - **Tests**
>   - Overhaul specs to build/parse new wire format; add signature verifier tests; rename expectations to `PERMISSIONLESS`; remove reliance on `target_l1_block`; update helpers and integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a88f84c432504f7dbaee60a60ef7fc9b25bc53e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->