### PR TITLE
Refactor EthRpcClient and L1RpcPrefetcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       tzinfo
     coderay (1.1.3)
     concurrent-ruby (1.3.3)
-    connection_pool (2.4.1)
+    connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.0)
     date (3.4.1)
@@ -171,8 +171,8 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.3.0)
-    net-http-persistent (4.0.2)
-      connection_pool (~> 2.2)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
     net-imap (0.5.8)
       date
       net-protocol

--- a/app/services/eth_block_importer.rb
+++ b/app/services/eth_block_importer.rb
@@ -15,7 +15,7 @@ class EthBlockImporter
     @facet_block_cache = {}
     @eth_block_cache = {}
     
-    @ethereum_client ||= EthRpcClient.new(ENV.fetch('L1_RPC_URL'))
+    @ethereum_client ||= EthRpcClient.l1
     
     @geth_driver = GethDriver
     
@@ -27,6 +27,13 @@ class EthBlockImporter
     populate_facet_block_cache
     
     @prefetcher = L1RpcPrefetcher.new(ethereum_client: @ethereum_client)
+
+    unless Rails.env.test?
+      max_block = current_max_eth_block_number
+      if max_block && max_block > 0
+        @prefetcher.ensure_prefetched(max_block + 1)
+      end
+    end
   end
   
   def current_max_facet_block_number
@@ -271,15 +278,15 @@ class EthBlockImporter
     start = Time.current
 
     # Fetch block data from prefetcher
-    response = prefetcher.fetch(block_number)
-
-    # Handle cancellation, fetch failure, or block not ready
-    if response.nil?
-      raise BlockNotReadyToImportError.new("Block #{block_number} fetch was cancelled or failed")
+    begin
+      response = prefetcher.fetch(block_number)
+    rescue L1RpcPrefetcher::BlockFetchError => e
+      raise BlockNotReadyToImportError.new(e.message)
     end
 
-    if response[:error] == :not_ready
-      raise BlockNotReadyToImportError.new("Block #{block_number} not yet available on L1")
+    # Handle cancellation or fetch failure
+    if response.nil?
+      raise BlockNotReadyToImportError.new("Block #{block_number} fetch was cancelled or failed")
     end
 
     eth_block = response[:eth_block]
@@ -329,9 +336,6 @@ class EthBlockImporter
   
   def import_next_block
     block_number = next_block_to_import
-
-    prefetcher.ensure_prefetched(block_number)
-
     import_single_block(block_number)
   end
   

--- a/app/services/eth_block_importer.rb
+++ b/app/services/eth_block_importer.rb
@@ -1,5 +1,3 @@
-require 'l1_rpc_prefetcher'
-
 class EthBlockImporter
   include SysConfig
   include Memery
@@ -26,7 +24,7 @@ class EthBlockImporter
     set_eth_block_starting_points
     populate_facet_block_cache
     
-    @prefetcher = L1RpcPrefetcher.new(ethereum_client: @ethereum_client)
+    @prefetcher = L1RpcPrefetcher.new(ethereum_client: EthRpcClient.l1_prefetch)
 
     unless Rails.env.test?
       max_block = current_max_eth_block_number

--- a/config/derive_facet_blocks.rb
+++ b/config/derive_facet_blocks.rb
@@ -83,7 +83,7 @@ module Clockwork
     end
   end
 
-  every(6.seconds, 'import_blocks_until_done') do
+  every(2.seconds, 'import_blocks_until_done') do
     importer = EthBlockImporter.new
 
     begin

--- a/config/derive_facet_blocks.rb
+++ b/config/derive_facet_blocks.rb
@@ -86,16 +86,21 @@ module Clockwork
   every(6.seconds, 'import_blocks_until_done') do
     importer = EthBlockImporter.new
 
-    loop do
-      begin
-        importer.import_blocks_until_done
-      rescue EthBlockImporter::ReorgDetectedError
-        Rails.logger.warn 'Reorg detected – reinitialising EthBlockImporter'
-        importer = EthBlockImporter.new
-        retry
-      end
+    begin
+      loop do
+        begin
+          importer.import_blocks_until_done
+        rescue EthBlockImporter::ReorgDetectedError
+          Rails.logger.warn 'Reorg detected – reinitialising EthBlockImporter'
+          importer.shutdown
+          importer = EthBlockImporter.new
+          retry
+        end
 
-      sleep 6
+        sleep 6
+      end
+    ensure
+      importer&.shutdown
     end
   end
 end

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       start_period: 10s
 
   node:
-    image: ghcr.io/0xfacet/facet-node:v2.0.1
+    image: ghcr.io/0xfacet/facet-node:v2.0.2
     environment:
       JWT_SECRET: ${JWT_SECRET}
       L1_NETWORK: ${L1_NETWORK}

--- a/lib/eth_rpc_client.rb
+++ b/lib/eth_rpc_client.rb
@@ -226,12 +226,11 @@ class EthRpcClient
   private
 
   def send_http_request_simple(data)
-    uri = URI(base_url)
-    request = Net::HTTP::Post.new(uri)
+    request = Net::HTTP::Post.new(@uri)
     request.body = data.to_json
     headers.each { |key, value| request[key] = value }
 
-    response = @http.request(uri, request)
+    response = @http.request(@uri, request)
 
     if response.code.to_i != 200
       raise HttpError.new(response.code.to_i, response.message)

--- a/lib/eth_rpc_client.rb
+++ b/lib/eth_rpc_client.rb
@@ -1,7 +1,9 @@
 class EthRpcClient
+  include Memery
+
   class HttpError < StandardError
     attr_reader :code, :http_message
-    
+
     def initialize(code, http_message)
       @code = code
       @http_message = http_message
@@ -9,19 +11,65 @@ class EthRpcClient
     end
   end
   class ApiError < StandardError; end
+  class ExecutionRevertedError < StandardError; end
   class MethodRequiredError < StandardError; end
-  attr_accessor :base_url
+  attr_accessor :base_url, :http
 
-  def initialize(base_url = ENV['L1_RPC_URL'])
+  def initialize(base_url = ENV['L1_RPC_URL'], jwt_secret: nil, retry_config: {})
     self.base_url = base_url
+    @request_id = 0
+    @mutex = Mutex.new
+
+    # JWT support (optional)
+    @jwt_secret = jwt_secret
+    @jwt_enabled = !jwt_secret.nil?
+
+    if @jwt_enabled
+      @jwt_secret_decoded = ByteString.from_hex(jwt_secret).to_bin
+    end
+
+    # Customizable retry configuration
+    @retry_config = {
+      tries: 7,
+      base_interval: 1,
+      max_interval: 32,
+      multiplier: 2,
+      rand_factor: 0.4
+    }.merge(retry_config)
+
+    # HTTP persistent connection pool
+    @uri = URI(base_url)
+    @http = Net::HTTP::Persistent.new(
+      name: "eth_rpc_#{@uri.host}:#{@uri.port}",
+      pool_size: 100
+    )
+    @http.open_timeout = 5    # 5 seconds to establish connection
+    @http.read_timeout = 10   # 10 seconds - allows multiple retries within prefetch timeout
+    @http.idle_timeout = 30   # Keep connections alive for 30 seconds
   end
-  
+
   def self.l1
     @_l1_client ||= new(ENV.fetch('L1_RPC_URL'))
   end
 
+  def self.l1_prefetch
+    # Fewer retries with shorter intervals for prefetching
+    @_l1_prefetch_client ||= new(
+      ENV.fetch('L1_RPC_URL'),
+      retry_config: { tries: 3, base_interval: 1, max_interval: 4 }
+    )
+  end
+
   def self.l2
     @_l2_client ||= new(ENV.fetch('NON_AUTH_GETH_RPC_URL'))
+  end
+
+  def self.l2_engine
+    @_l2_engine_client ||= new(
+      ENV.fetch('GETH_RPC_URL'),
+      jwt_secret: ENV.fetch('JWT_SECRET'),
+      retry_config: { tries: 5, base_interval: 0.5, max_interval: 4 }
+    )
   end
 
   def get_block(block_number, include_txs = false)
@@ -31,24 +79,24 @@ class EthRpcClient
         params: [block_number, include_txs]
       )
     end
-    
+
     query_api(
       method: 'eth_getBlockByNumber',
       params: ['0x' + block_number.to_s(16), include_txs]
     )
   end
-  
+
   def get_nonce(address, block_number = "latest")
     query_api(
       method: 'eth_getTransactionCount',
       params: [address, block_number]
     ).to_i(16)
   end
-  
+
   def get_chain_id
     query_api(method: 'eth_chainId').to_i(16)
   end
-  
+
   def trace_block(block_number)
     query_api(
       method: 'debug_traceBlockByNumber',
@@ -66,14 +114,14 @@ class EthRpcClient
   def trace(tx_hash)
     trace_transaction(tx_hash)
   end
-  
+
   def get_transaction(transaction_hash)
     query_api(
       method: 'eth_getTransactionByHash',
       params: [transaction_hash]
     )
   end
-  
+
   def get_transaction_receipts(block_number)
     if block_number.is_a?(String)
       return query_api(
@@ -81,24 +129,24 @@ class EthRpcClient
         params: [block_number]
       )
     end
-    
+
     query_api(
       method: 'eth_getBlockReceipts',
       params: ["0x" + block_number.to_s(16)]
     )
   end
-  
+
   def get_block_receipts(block_number)
     get_transaction_receipts(block_number)
   end
-  
+
   def get_transaction_receipt(transaction_hash)
     query_api(
       method: 'eth_getTransactionReceipt',
       params: [transaction_hash]
     )
   end
-  
+
   def get_block_number
     query_api(method: 'eth_blockNumber').to_i(16)
   end
@@ -108,65 +156,59 @@ class EthRpcClient
       method = kwargs[:method]
       params = kwargs[:params]
     end
-    
+
     unless method
       raise MethodRequiredError, "Method is required"
     end
-    
+
     data = {
-      id: 1,
+      id: next_request_id,
       jsonrpc: "2.0",
       method: method,
       params: params
     }
 
-    url = base_url
-    
     Retriable.retriable(
-      tries: 7,
-      base_interval: 1,
-      max_interval: 32,
-      multiplier: 2,
-      rand_factor: 0.4,
-      on: [Net::ReadTimeout, Net::OpenTimeout, HttpError, ApiError],
+      tries: @retry_config[:tries],
+      base_interval: @retry_config[:base_interval],
+      max_interval: @retry_config[:max_interval],
+      multiplier: @retry_config[:multiplier],
+      rand_factor: @retry_config[:rand_factor],
+      on: [Net::ReadTimeout, Net::OpenTimeout, HttpError, ApiError, Errno::EPIPE, EOFError, Errno::ECONNREFUSED],
       on_retry: ->(exception, try, elapsed_time, next_interval) {
-        Rails.logger.info "Retrying #{method} (attempt #{try}, next delay: #{next_interval.round(2)}s) - #{exception.message}"
+        Rails.logger.info "Retrying #{method} (attempt #{try}, next delay: #{next_interval&.round(2)}s) - #{exception.message}"
       }
     ) do
-      response = HTTParty.post(url, body: data.to_json, headers: headers)
-      
-      if response.code != 200
-        raise HttpError.new(response.code, response.message)
-      end
-
-      parsed_response = JSON.parse(response.body, max_nesting: false)
-      
-      if parsed_response['error']
-        raise ApiError, "API error: #{parsed_response.dig('error', 'message') || 'Unknown API error'}"
-      end
-
-      parsed_response['result']
+      send_http_request_simple(data)
     end
   end
 
   def call(method, params = [])
     query_api(method: method, params: params)
   end
-  
+
   def eth_call(to:, data:, block_number: "latest")
     query_api(
       method: 'eth_call',
       params: [{ to: to, data: data }, block_number]
     )
   end
-  
+
   def headers
-    { 
+    h = {
       'Accept' => 'application/json',
       'Content-Type' => 'application/json'
     }
+    h['Authorization'] = "Bearer #{jwt}" if @jwt_enabled
+    h
   end
-  
+
+  def jwt
+    return nil unless @jwt_enabled
+    JWT.encode({ iat: Time.now.to_i }, @jwt_secret_decoded, 'HS256')
+  end
+  memoize :jwt, ttl: 55
+
   def get_code(address, block_number = "latest")
     query_api(
       method: 'eth_getCode',
@@ -179,5 +221,43 @@ class EthRpcClient
       method: 'eth_getStorageAt',
       params: [address, slot, block_number]
     )
+  end
+
+  private
+
+  def send_http_request_simple(data)
+    uri = URI(base_url)
+    request = Net::HTTP::Post.new(uri)
+    request.body = data.to_json
+    headers.each { |key, value| request[key] = value }
+
+    response = @http.request(uri, request)
+
+    if response.code.to_i != 200
+      raise HttpError.new(response.code.to_i, response.message)
+    end
+
+    parse_response_and_handle_errors(response.body)
+  end
+
+  def parse_response_and_handle_errors(response_text)
+    parsed_response = JSON.parse(response_text, max_nesting: false)
+
+    if parsed_response['error']
+      error_message = parsed_response.dig('error', 'message') || 'Unknown API error'
+
+      # Don't retry execution reverted errors as they're deterministic failures
+      if error_message.include?('execution reverted')
+        raise ExecutionRevertedError, "API error: #{error_message}"
+      end
+
+      raise ApiError, "API error: #{error_message}"
+    end
+
+    parsed_response['result']
+  end
+
+  def next_request_id
+    @mutex.synchronize { @request_id += 1 }
   end
 end

--- a/lib/fct_mint_simulator.rb
+++ b/lib/fct_mint_simulator.rb
@@ -42,7 +42,7 @@ class FctMintSimulator
     @current_l2_block_number = nil
     
     # We'll fetch L1 blocks directly
-    @l1_client = EthRpcClient.new(ENV.fetch('L1_RPC_URL'))
+    @l1_client = EthRpcClient.l1
     
     if initial_state
       # Use provided initial state


### PR DESCRIPTION
- Upgraded connection_pool gem to version 3.0.2.
- Refactored EthRpcClient to include JWT support and improved retry configuration.
- Enhanced L1RpcPrefetcher to prevent prefetching beyond the chain tip and added error handling for block fetch failures.
- Updated EthBlockImporter to utilize new EthRpcClient methods for better clarity and performance.
- Adjusted tests to cover new behaviors in L1RpcPrefetcher.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes RPC and prefetch layers and makes block import more resilient and observable.
> 
> - Refactors `EthRpcClient` to use persistent connections with `Net::HTTP::Persistent`, configurable retries, optional JWT auth, unique request IDs, and explicit handling of `execution reverted`; adds `l1`, `l1_prefetch`, `l2`, and `l2_engine` helpers
> - Reworks `L1RpcPrefetcher` with chain-tip aware prefetching, fetch timeout, clearer error surface (`BlockFetchError`), promise cleanup/cancel, stats, and graceful `shutdown`; memoizes chain tip reads
> - Updates `EthBlockImporter` to use `EthRpcClient.l1`/`l1_prefetch`, pre-warm next block in non-test, map prefetch errors to `BlockNotReadyToImportError`, prune/remove extra prefetch calls, and add `shutdown`
> - Clockwork (`derive_facet_blocks.rb`): run every 2s, wrap loop in `begin/ensure` to call `shutdown`, and `shutdown` on reorg before reinit
> - Tests: expand `L1RpcPrefetcher` specs for not-ready, tip bounds, and shutdown; minor simulator tweak to use `EthRpcClient.l1`
> - Deps/infra: upgrade `connection_pool` and `net-http-persistent`; bump `facet-node` image to `v2.0.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c198990fe78e228cee94532da503df7f9699a5eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->